### PR TITLE
画角9分割による検出ブロックの追加

### DIFF
--- a/src/extensions/scratch3_akari_camera_simple/index.js
+++ b/src/extensions/scratch3_akari_camera_simple/index.js
@@ -362,6 +362,40 @@ class Scratch3AkariCameraSimple {
                     }
                 },
                 {
+                    opcode: 'isObjectVisibleColumns',
+                    text: '【もの】[NAME]が[COLUMN]でにんしきされた',
+                    blockType: BlockType.BOOLEAN,
+                    arguments: {
+                        NAME: {
+                            type: ArgumentType.STRING,
+                            menu: 'objects',
+                            defaultValue: objects.PERSON
+                        },
+                        COLUMN: {
+                            type: ArgumentType.STRING,
+                            menu: 'column',
+                            defaultValue: column.RIGHT
+                        }
+                    }
+                },
+                {
+                    opcode: 'isObjectVisibleRow',
+                    text: '【もの】[NAME]が[ROW]でにんしきされた',
+                    blockType: BlockType.BOOLEAN,
+                    arguments: {
+                        NAME: {
+                            type: ArgumentType.STRING,
+                            menu: 'objects',
+                            defaultValue: objects.PERSON
+                        },
+                        ROW: {
+                            type: ArgumentType.STRING,
+                            menu: 'row',
+                            defaultValue: row.UPPER
+                        }
+                    }
+                },
+                {
                     opcode: 'isObjectVisibleArea',
                     text: '【もの】[NAME]が[COLUMN]の[ROW]がわでにんしきされた',
                     blockType: BlockType.BOOLEAN,
@@ -530,6 +564,56 @@ class Scratch3AkariCameraSimple {
         for (let i = 0; i < objectResult.length; i++) {
             if (objectResult[i].name === args.NAME) {
                 return true;
+            }
+        }
+        return false;
+    }
+    isObjectVisibleColumns(args) {
+        for (let i = 0; i < objectResult.length; i++) {
+            if (objectResult[i].name === args.NAME) {
+                let x = getCenter(objectResult[i].x, objectResult[i].width)
+                let y = getCenter(objectResult[i].y, objectResult[i].height)
+                // 中央で検出
+                if (args.COLUMN === column.CENTER) {
+                    if (x <= COLUMN_SPLIT_THRESHOLD && x >= -COLUMN_SPLIT_THRESHOLD) {
+                        return true
+                    }
+                // 左側で検出
+                } else if (args.COLUMN === column.RIGHT) {
+                    if (x > COLUMN_SPLIT_THRESHOLD) {
+                        return true
+                    }
+                // 右側で検出
+                } else if (args.COLUMN === column.LEFT) {
+                    if (x < -COLUMN_SPLIT_THRESHOLD) {
+                        return true
+                    }
+                }
+            }
+        }
+        return false;
+    }
+    isObjectVisibleRow(args) {
+        for (let i = 0; i < objectResult.length; i++) {
+            if (objectResult[i].name === args.NAME) {
+                let x = getCenter(objectResult[i].x, objectResult[i].width)
+                let y = getCenter(objectResult[i].y, objectResult[i].height)
+                // 上側で検出
+                if (args.ROW === row.UPPER) {
+                    if (y < -ROW_SPLIT_THRESHOLD) {
+                        return true
+                    }
+                // 真ん中で検出
+                } else if (args.ROW === row.CENTER) {
+                    if (y <= ROW_SPLIT_THRESHOLD && y >= -ROW_SPLIT_THRESHOLD) {
+                        return true
+                    }
+                // 下側で検出
+                } else if (args.ROW === row.LOWER) {
+                    if (y > ROW_SPLIT_THRESHOLD) {
+                        return true
+                    }
+                }
             }
         }
         return false;

--- a/src/extensions/scratch3_akari_camera_simple/index.js
+++ b/src/extensions/scratch3_akari_camera_simple/index.js
@@ -602,6 +602,7 @@ class Scratch3AkariCameraSimple {
                 }
             }
         }
+    return false
     }
     getObjectNum(args) {
         let num = 0;

--- a/src/extensions/scratch3_akari_camera_simple/index.js
+++ b/src/extensions/scratch3_akari_camera_simple/index.js
@@ -73,6 +73,49 @@ function getCenter(pos, size) {
     return (pos + (size / 2));
 }
 
+function recognitionColumn(recognition_column, pos, size){
+    let x = getCenter(pos, size)
+    // 中央で検出
+    if (recognition_column === column.CENTER) {
+        if (x <= COLUMN_SPLIT_THRESHOLD && x >= -COLUMN_SPLIT_THRESHOLD) {
+            return true
+        }
+    // 左側で検出
+    } else if (recognition_column === column.RIGHT) {
+        if (x > COLUMN_SPLIT_THRESHOLD) {
+            return true
+        }
+    // 右側で検出
+    } else if (recognition_column === column.LEFT) {
+        if (x < -COLUMN_SPLIT_THRESHOLD) {
+            return true
+        }
+    }
+    return false
+}
+
+function recognitionRow(recognition_row, pos, size){
+    let y = getCenter(pos, size)
+    // 上側で検出
+    if (recognition_row === row.UPPER) {
+        if (y < -ROW_SPLIT_THRESHOLD) {
+            return true
+        }
+    // 真ん中で検出
+    } else if (recognition_row === row.CENTER) {
+        if (y <= ROW_SPLIT_THRESHOLD && y >= -ROW_SPLIT_THRESHOLD) {
+            return true
+        }
+    // 下側で検出
+    } else if (recognition_row === row.LOWER) {
+        if (y > ROW_SPLIT_THRESHOLD) {
+            return true
+        }
+    }
+    return false
+}
+
+
 class detectionResult {
     constructor(data) {
         this.name = data.name;
@@ -362,7 +405,7 @@ class Scratch3AkariCameraSimple {
                     }
                 },
                 {
-                    opcode: 'isObjectVisibleColumns',
+                    opcode: 'isObjectVisibleColumn',
                     text: '【もの】[NAME]が[COLUMN]でにんしきされた',
                     blockType: BlockType.BOOLEAN,
                     arguments: {
@@ -568,27 +611,10 @@ class Scratch3AkariCameraSimple {
         }
         return false;
     }
-    isObjectVisibleColumns(args) {
+    isObjectVisibleColumn(args) {
         for (let i = 0; i < objectResult.length; i++) {
             if (objectResult[i].name === args.NAME) {
-                let x = getCenter(objectResult[i].x, objectResult[i].width)
-                let y = getCenter(objectResult[i].y, objectResult[i].height)
-                // 中央で検出
-                if (args.COLUMN === column.CENTER) {
-                    if (x <= COLUMN_SPLIT_THRESHOLD && x >= -COLUMN_SPLIT_THRESHOLD) {
-                        return true
-                    }
-                // 左側で検出
-                } else if (args.COLUMN === column.RIGHT) {
-                    if (x > COLUMN_SPLIT_THRESHOLD) {
-                        return true
-                    }
-                // 右側で検出
-                } else if (args.COLUMN === column.LEFT) {
-                    if (x < -COLUMN_SPLIT_THRESHOLD) {
-                        return true
-                    }
-                }
+                return recognitionColumn(args.COLUMN, objectResult[i].x, objectResult[i].width)
             }
         }
         return false;
@@ -596,24 +622,7 @@ class Scratch3AkariCameraSimple {
     isObjectVisibleRow(args) {
         for (let i = 0; i < objectResult.length; i++) {
             if (objectResult[i].name === args.NAME) {
-                let x = getCenter(objectResult[i].x, objectResult[i].width)
-                let y = getCenter(objectResult[i].y, objectResult[i].height)
-                // 上側で検出
-                if (args.ROW === row.UPPER) {
-                    if (y < -ROW_SPLIT_THRESHOLD) {
-                        return true
-                    }
-                // 真ん中で検出
-                } else if (args.ROW === row.CENTER) {
-                    if (y <= ROW_SPLIT_THRESHOLD && y >= -ROW_SPLIT_THRESHOLD) {
-                        return true
-                    }
-                // 下側で検出
-                } else if (args.ROW === row.LOWER) {
-                    if (y > ROW_SPLIT_THRESHOLD) {
-                        return true
-                    }
-                }
+                return recognitionRow(args.ROW, objectResult[i].y, objectResult[i].height)
             }
         }
         return false;
@@ -621,68 +630,8 @@ class Scratch3AkariCameraSimple {
     isObjectVisibleArea(args) {
         for (let i = 0; i < objectResult.length; i++) {
             if (objectResult[i].name === args.NAME) {
-                let x = getCenter(objectResult[i].x, objectResult[i].width)
-                let y = getCenter(objectResult[i].y, objectResult[i].height)
-                // 中央で検出
-                if (args.COLUMN === column.CENTER) {
-                    if (x <= COLUMN_SPLIT_THRESHOLD && x >= -COLUMN_SPLIT_THRESHOLD) {
-                        // 上側で検出
-                        if (args.ROW === row.UPPER) {
-                            if (y < -ROW_SPLIT_THRESHOLD) {
-                                return true
-                            }
-                        // 真ん中で検出
-                        } else if (args.ROW === row.CENTER) {
-                            if (y <= ROW_SPLIT_THRESHOLD && y >= -ROW_SPLIT_THRESHOLD) {
-                                return true
-                            }
-                        // 下側で検出
-                        } else if (args.ROW === row.LOWER) {
-                            if (y > ROW_SPLIT_THRESHOLD) {
-                                return true
-                            }
-                        }
-                    }
-                // 左側で検出
-                } else if (args.COLUMN === column.RIGHT) {
-                    if (x >= COLUMN_SPLIT_THRESHOLD) {
-                        // 上側で検出
-                        if (args.ROW === row.UPPER) {
-                            if (y < -ROW_SPLIT_THRESHOLD) {
-                                return true
-                            }
-                        // 真ん中で検出
-                        } else if (args.ROW === row.CENTER) {
-                            if (y <= ROW_SPLIT_THRESHOLD && y >= -ROW_SPLIT_THRESHOLD) {
-                                return true
-                            }
-                        // 下側で検出
-                        } else if (args.ROW === row.LOWER) {
-                            if (y > ROW_SPLIT_THRESHOLD) {
-                                return true
-                            }
-                        }
-                    }
-                // 右側で検出
-                } else if (args.COLUMN === column.LEFT) {
-                    if (x <= -COLUMN_SPLIT_THRESHOLD) {
-                        // 上側で検出
-                        if (args.ROW === row.UPPER) {
-                            if (y < -ROW_SPLIT_THRESHOLD) {
-                                return true
-                            }
-                        // 真ん中で検出
-                        } else if (args.ROW === row.CENTER) {
-                            if (y <= ROW_SPLIT_THRESHOLD && y >= -ROW_SPLIT_THRESHOLD) {
-                                return true
-                            }
-                        // 下側で検出
-                        } else if (args.ROW === row.LOWER) {
-                            if (y > ROW_SPLIT_THRESHOLD) {
-                                return true
-                            }
-                        }
-                    }
+                if (recognitionColumn(args.COLUMN, objectResult[i].x, objectResult[i].width)){
+                    return recognitionRow(args.ROW, objectResult[i].y, objectResult[i].height)
                 }
             }
         }

--- a/src/extensions/scratch3_akari_camera_simple/index.js
+++ b/src/extensions/scratch3_akari_camera_simple/index.js
@@ -42,8 +42,20 @@ const objects = {
     BUS: 'bus',
     TRAIN: 'train'
 };
+const column = {
+    RIGHT: 'right',
+    CENTER: 'center',
+    LEFT: 'left'
+};
+const row = {
+    UPPER: 'upper',
+    CENTER: 'center',
+    LOWER: 'lower'
+};
 
-const DETECTION_IMAGE_SIZE = [640, 480];
+const DETECTION_IMAGE_SIZE = [480, 360];
+const COLUMN_SPLIT_THRESHOLD = 0.3
+const ROW_SPLIT_THRESHOLD = 0.3
 
 
 // eslint-disable-next-line func-style, require-jsdoc
@@ -238,6 +250,38 @@ class Scratch3AkariCameraSimple {
             }
         ];
     }
+    get COLUMN_MENU() {
+        return [
+            {
+                text: 'みぎ',
+                value: column.RIGHT
+            },
+            {
+                text: 'まんなか',
+                value: column.CENTER
+            },
+            {
+                text: 'ひだり',
+                value: column.LEFT
+            }
+        ];
+    }
+    get ROW_MENU() {
+        return [
+            {
+                text: 'うえ',
+                value: row.UPPER
+            },
+            {
+                text: 'まんなか',
+                value: column.CENTER
+            },
+            {
+                text: 'した',
+                value: row.LOWER
+            }
+        ];
+    }
     getInfo() {
         return {
             id: 'akaricamerasimple',
@@ -318,6 +362,28 @@ class Scratch3AkariCameraSimple {
                     }
                 },
                 {
+                    opcode: 'isObjectVisibleArea',
+                    text: '【もの】[NAME]が[COLUMN]の[ROW]がわでにんしきされた',
+                    blockType: BlockType.BOOLEAN,
+                    arguments: {
+                        NAME: {
+                            type: ArgumentType.STRING,
+                            menu: 'objects',
+                            defaultValue: objects.PERSON
+                        },
+                        COLUMN: {
+                            type: ArgumentType.STRING,
+                            menu: 'column',
+                            defaultValue: column.CENTER
+                        },
+                        ROW: {
+                            type: ArgumentType.STRING,
+                            menu: 'row',
+                            defaultValue: row.UPPER
+                        }
+                    }
+                },
+                {
                     opcode: 'getObjectNum',
                     text: '【もの】にんしきした[NAME]のかず',
                     blockType: BlockType.REPORTER,
@@ -391,6 +457,14 @@ class Scratch3AkariCameraSimple {
                 objects: {
                     acceptReporters: true,
                     items: this.OBJECTS_MENU
+                },
+                column: {
+                    acceptReporters: true,
+                    items: this.COLUMN_MENU
+                },
+                row: {
+                    acceptReporters: true,
+                    items: this.ROW_MENU
                 }
             }
         };
@@ -459,6 +533,75 @@ class Scratch3AkariCameraSimple {
             }
         }
         return false;
+    }
+    isObjectVisibleArea(args) {
+        for (let i = 0; i < objectResult.length; i++) {
+            if (objectResult[i].name === args.NAME) {
+                let x = getCenter(objectResult[i].x, objectResult[i].width)
+                let y = getCenter(objectResult[i].y, objectResult[i].height)
+                // 中央で検出
+                if (args.COLUMN === column.CENTER) {
+                    if (x <= COLUMN_SPLIT_THRESHOLD && x >= -COLUMN_SPLIT_THRESHOLD) {
+                        // 上側で検出
+                        if (args.ROW === row.UPPER) {
+                            if (y < -ROW_SPLIT_THRESHOLD) {
+                                return true
+                            }
+                        // 真ん中で検出
+                        } else if (args.ROW === row.CENTER) {
+                            if (y <= ROW_SPLIT_THRESHOLD && y >= -ROW_SPLIT_THRESHOLD) {
+                                return true
+                            }
+                        // 下側で検出
+                        } else if (args.ROW === row.LOWER) {
+                            if (y > ROW_SPLIT_THRESHOLD) {
+                                return true
+                            }
+                        }
+                    }
+                // 左側で検出
+                } else if (args.COLUMN === column.RIGHT) {
+                    if (x >= COLUMN_SPLIT_THRESHOLD) {
+                        // 上側で検出
+                        if (args.ROW === row.UPPER) {
+                            if (y < -ROW_SPLIT_THRESHOLD) {
+                                return true
+                            }
+                        // 真ん中で検出
+                        } else if (args.ROW === row.CENTER) {
+                            if (y <= ROW_SPLIT_THRESHOLD && y >= -ROW_SPLIT_THRESHOLD) {
+                                return true
+                            }
+                        // 下側で検出
+                        } else if (args.ROW === row.LOWER) {
+                            if (y > ROW_SPLIT_THRESHOLD) {
+                                return true
+                            }
+                        }
+                    }
+                // 右側で検出
+                } else if (args.COLUMN === column.LEFT) {
+                    if (x <= -COLUMN_SPLIT_THRESHOLD) {
+                        // 上側で検出
+                        if (args.ROW === row.UPPER) {
+                            if (y < -ROW_SPLIT_THRESHOLD) {
+                                return true
+                            }
+                        // 真ん中で検出
+                        } else if (args.ROW === row.CENTER) {
+                            if (y <= ROW_SPLIT_THRESHOLD && y >= -ROW_SPLIT_THRESHOLD) {
+                                return true
+                            }
+                        // 下側で検出
+                        } else if (args.ROW === row.LOWER) {
+                            if (y > ROW_SPLIT_THRESHOLD) {
+                                return true
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
     getObjectNum(args) {
         let num = 0;


### PR DESCRIPTION
カメラ画角を上下左右、真ん中で9分割て各エリアに物体が検出されたときにTrueを返すブロックを追加しました。